### PR TITLE
Ignore Last Action Event When Creating a Recording (#132)

### DIFF
--- a/openadapt/crud.py
+++ b/openadapt/crud.py
@@ -138,15 +138,15 @@ def remove_latest_action_event_from_recording():
         logger.info(f"canonical character name 1: {action_event_1.canonical_key_char}")
         logger.info(f"canonical key name 2: {action_event_2.canonical_key_name}")
 
-        if ((action_event_1.canonical_key_char == "c") and \
-            (action_event_2.canonical_key_name == "ctrl")):
-            #executes if ctrl+c or cmd+c was pressed as the latest action event
+        if ((action_event_1.canonical_key_char == "c") and (
+            action_event_2.canonical_key_name == "ctrl")):
+            #executes if ctrl+c was pressed as the latest action event
             db.delete(action_event_1)
             db.delete(action_event_2)
             db.commit()
             logger.info("Latest action event was removed from recording.")
         else:
-            logger.info("Recording was not interrupted by Ctrl+C or Cmd+C.")
+            logger.info("Recording was not interrupted by Ctrl+C.")
     else:
         logger.info("No action events found in latest recording.")
 

--- a/openadapt/record.py
+++ b/openadapt/record.py
@@ -31,6 +31,7 @@ from openadapt.crud import (
     insert_screenshot,
     insert_recording,
     insert_window_event,
+    remove_latest_action_event_from_recording
 )
 from openadapt.utils import (
     configure_logging,
@@ -689,6 +690,8 @@ def record(
     plot_performance(recording_timestamp, perf_q)
 
     logger.info("done")
+    remove_latest_action_event_from_recording()
+    logger.info("done cleaning up")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Solves Issue #132 , Approach 1
Summary: 
 - Whenever creating a recording, the use of 'Ctrl+c' or 'Command+c', leaves an unneeded ActionEvent of holding Ctrl or Command.
 - When replaying the recording, the key is held down indefinitely until pressed and released by the user.

Solution:
 - Once the KeyboardInterrupt is received, the recording is processed, and the last ActionEvent is removed.
 - Added function: remove_latest_action_event_from_recording, to record.py.
 
 Assumption:
 - record.py will always be terminated by either 'Ctrl+c' or 'Command+c'.