### PR TITLE
Investigated Pyment #181

### DIFF
--- a/openadapt/cache.py
+++ b/openadapt/cache.py
@@ -9,18 +9,42 @@ from openadapt import config
 
 
 def default(val, default):
+    """
+
+    :param val: 
+    :param default: 
+
+    """
     return val if val is not None else default
 
 
 def cache(dir_path=None, enabled=None, verbosity=None, **cache_kwargs):
-    """TODO"""
+    """TODO
+
+    :param dir_path:  (Default value = None)
+    :param enabled:  (Default value = None)
+    :param verbosity:  (Default value = None)
+    :param **cache_kwargs: 
+
+    """
 
     cache_dir_path = default(dir_path, config.CACHE_DIR_PATH)
     cache_enabled = default(enabled, config.CACHE_ENABLED)
     cache_verbosity = default(verbosity, config.CACHE_VERBOSITY)
     def decorator(fn):
+        """
+
+        :param fn: 
+
+        """
         @wraps(fn)
         def wrapper(*args, **kwargs):
+            """
+
+            :param *args: 
+            :param **kwargs: 
+
+            """
             logger.debug(f"{cache_enabled=}")
             if cache_enabled:
                 memory = Memory(cache_dir_path, verbose=cache_verbosity)

--- a/openadapt/config.py
+++ b/openadapt/config.py
@@ -23,6 +23,11 @@ _DEFAULTS = {
 
 
 def getenv_fallback(var_name):
+    """
+
+    :param var_name: 
+
+    """
     rval = os.getenv(var_name) or _DEFAULTS.get(var_name)
     if rval is None:
         raise ValueError(f"{var_name=} not defined")

--- a/openadapt/crud.py
+++ b/openadapt/crud.py
@@ -14,7 +14,13 @@ window_events = []
 
 
 def _insert(event_data, table, buffer=None):
-    """Insert using Core API for improved performance (no rows are returned)"""
+    """Insert using Core API for improved performance (no rows are returned)
+
+    :param event_data: 
+    :param table: 
+    :param buffer:  (Default value = None)
+
+    """
 
     db_obj = {
         column.name: None
@@ -43,6 +49,13 @@ def _insert(event_data, table, buffer=None):
 
 
 def insert_action_event(recording_timestamp, event_timestamp, event_data):
+    """
+
+    :param recording_timestamp: 
+    :param event_timestamp: 
+    :param event_data: 
+
+    """
     event_data = {
         **event_data,
         "timestamp": event_timestamp,
@@ -52,6 +65,13 @@ def insert_action_event(recording_timestamp, event_timestamp, event_data):
 
 
 def insert_screenshot(recording_timestamp, event_timestamp, event_data):
+    """
+
+    :param recording_timestamp: 
+    :param event_timestamp: 
+    :param event_data: 
+
+    """
     event_data = {
         **event_data,
         "timestamp": event_timestamp,
@@ -61,6 +81,13 @@ def insert_screenshot(recording_timestamp, event_timestamp, event_data):
 
 
 def insert_window_event(recording_timestamp, event_timestamp, event_data):
+    """
+
+    :param recording_timestamp: 
+    :param event_timestamp: 
+    :param event_data: 
+
+    """
     event_data = {
         **event_data,
         "timestamp": event_timestamp,
@@ -70,6 +97,11 @@ def insert_window_event(recording_timestamp, event_timestamp, event_data):
 
 
 def insert_recording(recording_data):
+    """
+
+    :param recording_data: 
+
+    """
     db_obj = Recording(**recording_data)
     db.add(db_obj)
     db.commit()
@@ -78,6 +110,7 @@ def insert_recording(recording_data):
 
 
 def get_latest_recording():
+    """ """
     return (
         db
         .query(Recording)
@@ -88,6 +121,11 @@ def get_latest_recording():
 
 
 def get_recording(timestamp):
+    """
+
+    :param timestamp: 
+
+    """
     return (
         db
         .query(Recording)
@@ -97,6 +135,12 @@ def get_recording(timestamp):
 
 
 def _get(table, recording_timestamp):
+    """
+
+    :param table: 
+    :param recording_timestamp: 
+
+    """
     return (
         db
         .query(table)
@@ -107,10 +151,21 @@ def _get(table, recording_timestamp):
 
 
 def get_action_events(recording):
+    """
+
+    :param recording: 
+
+    """
     return _get(ActionEvent, recording.timestamp)
 
 
 def get_screenshots(recording, precompute_diffs=False):
+    """
+
+    :param recording: 
+    :param precompute_diffs:  (Default value = False)
+
+    """
     screenshots = _get(Screenshot, recording.timestamp)
 
     for prev, cur in zip(screenshots, screenshots[1:]):
@@ -126,4 +181,9 @@ def get_screenshots(recording, precompute_diffs=False):
 
 
 def get_window_events(recording):
+    """
+
+    :param recording: 
+
+    """
     return _get(WindowEvent, recording.timestamp)

--- a/openadapt/db.py
+++ b/openadapt/db.py
@@ -18,6 +18,7 @@ NAMING_CONVENTION = {
 
 
 class BaseModel(DictableModel):
+    """ """
 
     __abstract__ = True
 
@@ -31,6 +32,7 @@ class BaseModel(DictableModel):
 
 
 def get_engine():
+    """ """
     engine = sa.create_engine(
         DB_URL,
         echo=DB_ECHO,
@@ -39,6 +41,11 @@ def get_engine():
 
 
 def get_base(engine):
+    """
+
+    :param engine: 
+
+    """
     metadata = MetaData(naming_convention=NAMING_CONVENTION)
     Base = declarative_base(
         cls=BaseModel,

--- a/openadapt/models.py
+++ b/openadapt/models.py
@@ -11,16 +11,24 @@ from openadapt import db, utils, window
 
 # https://groups.google.com/g/sqlalchemy/c/wlr7sShU6-k
 class ForceFloat(sa.TypeDecorator):
+    """ """
     impl = sa.Numeric(10, 2, asdecimal=False)
     cache_ok = True
 
     def process_result_value(self, value, dialect):
+        """
+
+        :param value: 
+        :param dialect: 
+
+        """
         if value is not None:
             value = float(value)
         return value
 
 
 class Recording(db.Base):
+    """ """
     __tablename__ = "recording"
 
     id = sa.Column(sa.Integer, primary_key=True)
@@ -52,6 +60,7 @@ class Recording(db.Base):
 
     @property
     def processed_action_events(self):
+        """ """
         from openadapt import events
         if not self._processed_action_events:
             self._processed_action_events = events.get_events(self)
@@ -60,6 +69,7 @@ class Recording(db.Base):
 
 
 class ActionEvent(db.Base):
+    """ """
     __tablename__ = "action_event"
 
     id = sa.Column(sa.Integer, primary_key=True)
@@ -96,6 +106,13 @@ class ActionEvent(db.Base):
     # TODO: playback_timestamp / original_timestamp
 
     def _key(self, key_name, key_char, key_vk):
+        """
+
+        :param key_name: 
+        :param key_char: 
+        :param key_vk: 
+
+        """
         if key_name:
             key = keyboard.Key[key_name]
         elif key_char:
@@ -109,6 +126,7 @@ class ActionEvent(db.Base):
 
     @property
     def key(self):
+        """ """
         logger.trace(
             f"{self.name=} {self.key_name=} {self.key_char=} {self.key_vk=}"
         )
@@ -120,6 +138,7 @@ class ActionEvent(db.Base):
 
     @property
     def canonical_key(self):
+        """ """
         logger.trace(
             f"{self.name=} "
             f"{self.canonical_key_name=} "
@@ -133,6 +152,11 @@ class ActionEvent(db.Base):
         )
 
     def _text(self, canonical=False):
+        """
+
+        :param canonical:  (Default value = False)
+
+        """
         sep = self._text_sep
         name_prefix = self._text_name_prefix
         name_suffix = self._text_name_suffix
@@ -165,10 +189,12 @@ class ActionEvent(db.Base):
 
     @property
     def text(self):
+        """ """
         return self._text()
 
     @property
     def canonical_text(self):
+        """ """
         return self._text(canonical=True)
 
     def __str__(self):
@@ -207,6 +233,11 @@ class ActionEvent(db.Base):
 
     @classmethod
     def from_children(cls, children_dicts):
+        """
+
+        :param children_dicts: 
+
+        """
         children = [
             ActionEvent(**child_dict)
             for child_dict in children_dicts
@@ -215,6 +246,7 @@ class ActionEvent(db.Base):
 
 
 class Screenshot(db.Base):
+    """ """
     __tablename__ = "screenshot"
 
     id = sa.Column(sa.Integer, primary_key=True)
@@ -236,6 +268,7 @@ class Screenshot(db.Base):
 
     @property
     def image(self):
+        """ """
         if not self._image:
             if self.sct_img:
                 self._image = Image.frombytes(
@@ -252,6 +285,7 @@ class Screenshot(db.Base):
 
     @property
     def diff(self):
+        """ """
         if not self._diff:
             assert self.prev, "Attempted to compute diff before setting prev"
             self._diff = ImageChops.difference(self.image, self.prev.image)
@@ -259,6 +293,7 @@ class Screenshot(db.Base):
 
     @property
     def diff_mask(self):
+        """ """
         if not self._diff_mask:
             if self.diff:
                 self._diff_mask = self.diff.convert("1")
@@ -266,16 +301,19 @@ class Screenshot(db.Base):
 
     @property
     def array(self):
+        """ """
         return np.array(self.image)
 
     @classmethod
     def take_screenshot(cls):
+        """ """
         sct_img = utils.take_screenshot()
         screenshot = Screenshot(sct_img=sct_img)
         return screenshot
 
 
 class WindowEvent(db.Base):
+    """ """
     __tablename__ = "window_event"
 
     id = sa.Column(sa.Integer, primary_key=True)
@@ -294,4 +332,5 @@ class WindowEvent(db.Base):
 
     @classmethod
     def get_active_window_event(cls):
+        """ """
         return WindowEvent(**window.get_active_window_data())

--- a/openadapt/playback.py
+++ b/openadapt/playback.py
@@ -7,6 +7,12 @@ from openadapt.common import KEY_EVENTS, MOUSE_EVENTS
 
 
 def play_mouse_event(event, mouse_controller):
+    """
+
+    :param event: 
+    :param mouse_controller: 
+
+    """
     name = event.name
     assert name in MOUSE_EVENTS, event
     x = event.mouse_x
@@ -39,6 +45,13 @@ def play_mouse_event(event, mouse_controller):
 
 
 def play_key_event(event, keyboard_controller, canonical=True):
+    """
+
+    :param event: 
+    :param keyboard_controller: 
+    :param canonical:  (Default value = True)
+
+    """
     assert event.name in KEY_EVENTS, event
 
     key = (
@@ -57,6 +70,13 @@ def play_key_event(event, keyboard_controller, canonical=True):
 
 
 def play_action_event(event, mouse_controller, keyboard_controller):
+    """
+
+    :param event: 
+    :param mouse_controller: 
+    :param keyboard_controller: 
+
+    """
     # currently we use children to replay type events
     if event.children and event.name in KEY_EVENTS:
         for child in event.children:

--- a/openadapt/record.py
+++ b/openadapt/record.py
@@ -43,6 +43,15 @@ Event = namedtuple("Event", ("timestamp", "type", "data"))
 
 
 def process_event(event, write_q, write_fn, recording_timestamp, perf_q):
+    """
+
+    :param event: 
+    :param write_q: 
+    :param write_fn: 
+    :param recording_timestamp: 
+    :param perf_q: 
+
+    """
     if PROC_WRITE_BY_EVENT_TYPE[event.type]:
         write_q.put(event)
     else:
@@ -58,17 +67,23 @@ def process_events(
     recording_timestamp: float,
     terminate_event: multiprocessing.Event,
 ):
-    """
-    Process events from event queue and write them to respective write queues.
+    """Process events from event queue and write them to respective write queues.
 
-    Args:
-        event_q: A queue with events to be processed.
-        screen_write_q: A queue for writing screen events.
-        action_write_q: A queue for writing action events.
-        window_write_q: A queue for writing window events.
-        perf_q: A queue for collecting performance data.
-        recording_timestamp: The timestamp of the recording.
-        terminate_event: An event to signal the termination of the process.
+    :param event_q: A queue with events to be processed.
+    :param screen_write_q: A queue for writing screen events.
+    :param action_write_q: A queue for writing action events.
+    :param window_write_q: A queue for writing window events.
+    :param perf_q: A queue for collecting performance data.
+    :param recording_timestamp: The timestamp of the recording.
+    :param terminate_event: An event to signal the termination of the process.
+    :param event_q: queue.Queue: 
+    :param screen_write_q: multiprocessing.Queue: 
+    :param action_write_q: multiprocessing.Queue: 
+    :param window_write_q: multiprocessing.Queue: 
+    :param perf_q: multiprocessing.Queue: 
+    :param recording_timestamp: float: 
+    :param terminate_event: multiprocessing.Event: 
+
     """
 
     utils.configure_logging(logger, LOG_LEVEL)
@@ -135,13 +150,15 @@ def write_action_event(
     event: Event,
     perf_q: multiprocessing.Queue,
 ):
-    """
-    Write an action event to the database and update the performance queue.
+    """Write an action event to the database and update the performance queue.
 
-    Args:
-        recording_timestamp: The timestamp of the recording.
-        event: An action event to be written.
-        perf_q: A queue for collecting performance data.
+    :param recording_timestamp: The timestamp of the recording.
+    :param event: An action event to be written.
+    :param perf_q: A queue for collecting performance data.
+    :param recording_timestamp: float: 
+    :param event: Event: 
+    :param perf_q: multiprocessing.Queue: 
+
     """
 
     assert event.type == "action", event
@@ -154,13 +171,15 @@ def write_screen_event(
     event: Event,
     perf_q: multiprocessing.Queue,
 ):
-    """
-    Write a screen event to the database and update the performance queue.
+    """Write a screen event to the database and update the performance queue.
 
-    Args:
-        recording_timestamp: The timestamp of the recording.
-        event: A screen event to be written.
-        perf_q: A queue for collecting performance data.
+    :param recording_timestamp: The timestamp of the recording.
+    :param event: A screen event to be written.
+    :param perf_q: A queue for collecting performance data.
+    :param recording_timestamp: float: 
+    :param event: Event: 
+    :param perf_q: multiprocessing.Queue: 
+
     """
 
     assert event.type == "screen", event
@@ -176,13 +195,15 @@ def write_window_event(
     event: Event,
     perf_q: multiprocessing.Queue,
 ):
-    """
-    Write a window event to the database and update the performance queue.
+    """Write a window event to the database and update the performance queue.
 
-    Args:
-        recording_timestamp: The timestamp of the recording.
-        event: A window event to be written.
-        perf_q: A queue for collecting performance data.
+    :param recording_timestamp: The timestamp of the recording.
+    :param event: A window event to be written.
+    :param perf_q: A queue for collecting performance data.
+    :param recording_timestamp: float: 
+    :param event: Event: 
+    :param perf_q: multiprocessing.Queue: 
+
     """
 
     assert event.type == "window", event
@@ -198,16 +219,21 @@ def write_events(
     recording_timestamp: float,
     terminate_event: multiprocessing.Event,
 ):
-    """
-    Write events of a specific type to the db using the provided write function.
+    """Write events of a specific type to the db using the provided write function.
 
-    Args:
-        event_type: The type of events to be written.
-        write_fn: A function to write events to the database.
-        write_q: A queue with events to be written.
-        perf_q: A queue for collecting performance data.
-        recording_timestamp: The timestamp of the recording.
-        terminate_event: An event to signal the termination of the process.
+    :param event_type: The type of events to be written.
+    :param write_fn: A function to write events to the database.
+    :param write_q: A queue with events to be written.
+    :param perf_q: A queue for collecting performance data.
+    :param recording_timestamp: The timestamp of the recording.
+    :param terminate_event: An event to signal the termination of the process.
+    :param event_type: str: 
+    :param write_fn: Callable: 
+    :param write_q: multiprocessing.Queue: 
+    :param perf_q: multiprocessing.Queue: 
+    :param recording_timestamp: float: 
+    :param terminate_event: multiprocessing.Event: 
+
     """
 
     utils.configure_logging(logger, LOG_LEVEL)
@@ -229,6 +255,13 @@ def trigger_action_event(
     event_q: queue.Queue,
     action_event_args: Dict[str, Any],
 ) -> None:
+    """
+
+    :param event_q: queue.Queue: 
+    :param action_event_args: Dict[str: 
+    :param Any]: 
+
+    """
     x = action_event_args.get("mouse_x")
     y = action_event_args.get("mouse_y")
     if x is not None and y is not None:
@@ -246,6 +279,14 @@ def on_move(
     y: int,
     injected: bool,
 ) -> None:
+    """
+
+    :param event_q: queue.Queue: 
+    :param x: int: 
+    :param y: int: 
+    :param injected: bool: 
+
+    """
 
     logger.debug(f"{x=} {y=} {injected=}")
     if not injected:
@@ -267,6 +308,16 @@ def on_click(
     pressed: bool,
     injected: bool,
 ) -> None:
+    """
+
+    :param event_q: queue.Queue: 
+    :param x: int: 
+    :param y: int: 
+    :param button: mouse.Button: 
+    :param pressed: bool: 
+    :param injected: bool: 
+
+    """
     logger.debug(f"{x=} {y=} {button=} {pressed=} {injected=}")
     if not injected:
         trigger_action_event(
@@ -289,6 +340,16 @@ def on_scroll(
     dy: int,
     injected: bool,
 ) -> None:
+    """
+
+    :param event_q: queue.Queue: 
+    :param x: int: 
+    :param y: int: 
+    :param dx: int: 
+    :param dy: int: 
+    :param injected: bool: 
+
+    """
     logger.debug(f"{x=} {y=} {dx=} {dy=} {injected=}")
     if not injected:
         trigger_action_event(
@@ -309,6 +370,14 @@ def handle_key(
     key: keyboard.KeyCode,
     canonical_key: keyboard.KeyCode,
 ) -> None:
+    """
+
+    :param event_q: queue.Queue: 
+    :param event_name: str: 
+    :param key: keyboard.KeyCode: 
+    :param canonical_key: keyboard.KeyCode: 
+
+    """
     attr_names = [
         "name",
         "char",
@@ -339,13 +408,15 @@ def read_screen_events(
     terminate_event: multiprocessing.Event,
     recording_timestamp: float,
 ) -> None:
-    """
-    Read screen events and add them to the event queue.
+    """Read screen events and add them to the event queue.
 
-    Args:
-        event_q: A queue for adding screen events.
-        terminate_event: An event to signal the termination of the process.
-        recording_timestamp: The timestamp of the recording.
+    :param event_q: A queue for adding screen events.
+    :param terminate_event: An event to signal the termination of the process.
+    :param recording_timestamp: The timestamp of the recording.
+    :param event_q: queue.Queue: 
+    :param terminate_event: multiprocessing.Event: 
+    :param recording_timestamp: float: 
+
     """
 
     utils.configure_logging(logger, LOG_LEVEL)
@@ -365,13 +436,15 @@ def read_window_events(
 	terminate_event: multiprocessing.Event,
 	recording_timestamp: float,
 ) -> None:
-    """
-    Read window events and add them to the event queue.
+    """Read window events and add them to the event queue.
 
-    Args:
-        event_q: A queue for adding window events.
-        terminate_event: An event to signal the termination of the process.
-        recording_timestamp: The timestamp of the recording.
+    :param event_q: A queue for adding window events.
+    :param terminate_event: An event to signal the termination of the process.
+    :param recording_timestamp: The timestamp of the recording.
+    :param event_q: queue.Queue: 
+    :param terminate_event: multiprocessing.Event: 
+    :param recording_timestamp: float: 
+
     """
 
     utils.configure_logging(logger, LOG_LEVEL)
@@ -410,12 +483,13 @@ def plot_performance(
     recording_timestamp: float,
     perf_q: multiprocessing.Queue,
 ) -> None:
-    """
-    Plot the performance of the event processing and writing.
+    """Plot the performance of the event processing and writing.
 
-    Args:
-        recording_timestamp: The timestamp of the recording.
-        perf_q: A queue with performance data.
+    :param recording_timestamp: The timestamp of the recording.
+    :param perf_q: A queue with performance data.
+    :param recording_timestamp: float: 
+    :param perf_q: multiprocessing.Queue: 
+
     """
 
     type_to_prev_start_time = defaultdict(list)
@@ -465,15 +539,13 @@ def plot_performance(
 def create_recording(
     task_description: str,
 ) -> Dict[str, Any]:
-    """
-    Create a new recording entry in the database.
+    """Create a new recording entry in the database.
 
-    Args:
-        task_description: a text description of the task being implemented
+    :param task_description: a text description of the task being implemented
             in the recording
+    :param task_description: str: 
+    :returns: The newly created Recording object
 
-    Returns:
-        The newly created Recording object
     """
 
     timestamp = utils.set_start_time()
@@ -500,9 +572,23 @@ def read_keyboard_events(
 	terminate_event: multiprocessing.Event,
 	recording_timestamp: float,
 ) -> None:
+    """
+
+    :param event_q: queue.Queue: 
+    :param terminate_event: multiprocessing.Event: 
+    :param recording_timestamp: float: 
+
+    """
 
 
     def on_press(event_q, key, injected):
+        """
+
+        :param event_q: 
+        :param key: 
+        :param injected: 
+
+        """
         canonical_key = keyboard_listener.canonical(key)
         logger.debug(f"{key=} {injected=} {canonical_key=}")
         if not injected:
@@ -510,6 +596,13 @@ def read_keyboard_events(
 
 
     def on_release(event_q, key, injected):
+        """
+
+        :param event_q: 
+        :param key: 
+        :param injected: 
+
+        """
         canonical_key = keyboard_listener.canonical(key)
         logger.debug(f"{key=} {injected=} {canonical_key=}")
         if not injected:
@@ -531,6 +624,13 @@ def read_mouse_events(
     terminate_event: multiprocessing.Event,
     recording_timestamp: float,
 ) -> None:
+    """
+
+    :param event_q: queue.Queue: 
+    :param terminate_event: multiprocessing.Event: 
+    :param recording_timestamp: float: 
+
+    """
     utils.set_start_time(recording_timestamp)
     mouse_listener = mouse.Listener(
         on_move=partial(on_move, event_q),
@@ -545,11 +645,11 @@ def read_mouse_events(
 def record(
     task_description: str,
 ):
-    """
-    Record Screenshots/ActionEvents/WindowEvents.
+    """Record Screenshots/ActionEvents/WindowEvents.
 
-    Args:
-        task_description: a text description of the task that will be recorded
+    :param task_description: a text description of the task that will be recorded
+    :param task_description: str: 
+
     """
 
     utils.configure_logging(logger, LOG_LEVEL)

--- a/openadapt/replay.py
+++ b/openadapt/replay.py
@@ -15,6 +15,13 @@ def replay(
     strategy_name: str,
     timestamp: Union[str, None] = None,
 ):
+    """
+
+    :param strategy_name: str: 
+    :param timestamp: Union[str: 
+    :param None]:  (Default value = None)
+
+    """
     utils.configure_logging(logger, LOG_LEVEL)
 
     if timestamp:

--- a/openadapt/strategies/base.py
+++ b/openadapt/strategies/base.py
@@ -18,6 +18,7 @@ MAX_FRAME_TIMES = 1000
 
 
 class BaseReplayStrategy(ABC):
+    """ """
 
     def __init__(
         self,
@@ -36,9 +37,15 @@ class BaseReplayStrategy(ABC):
         self,
         screenshot: models.Screenshot,
     ) -> models.ActionEvent:
+        """
+
+        :param screenshot: models.Screenshot: 
+
+        """
         pass
 
     def run(self):
+        """ """
         keyboard_controller = keyboard.Controller()
         mouse_controller = mouse.Controller()
         while True:
@@ -79,6 +86,7 @@ class BaseReplayStrategy(ABC):
                     import ipdb; ipdb.set_trace()
 
     def log_fps(self):
+        """ """
         t = time.time()
         self.frame_times.append(t)
         dts = np.diff(self.frame_times)

--- a/openadapt/strategies/base.py
+++ b/openadapt/strategies/base.py
@@ -39,6 +39,7 @@ class BaseReplayStrategy(ABC):
     ) -> models.ActionEvent:
         """
 
+        :param screenshot: models.Screenshot:
         :param screenshot: models.Screenshot: 
 
         """

--- a/openadapt/strategies/demo.py
+++ b/openadapt/strategies/demo.py
@@ -42,6 +42,8 @@ class DemoReplayStrategy(
     ):
         """
 
+        :param screenshot: Screenshot:
+        :param window_event: WindowEvent:
         :param screenshot: Screenshot: 
         :param window_event: WindowEvent: 
 

--- a/openadapt/strategies/demo.py
+++ b/openadapt/strategies/demo.py
@@ -26,6 +26,7 @@ class DemoReplayStrategy(
     ASCIIReplayStrategyMixin,
     BaseReplayStrategy,
 ):
+    """ """
 
     def __init__(
         self,
@@ -39,6 +40,12 @@ class DemoReplayStrategy(
         screenshot: Screenshot,
         window_event: WindowEvent,
     ):
+        """
+
+        :param screenshot: Screenshot: 
+        :param window_event: WindowEvent: 
+
+        """
         ascii_text = self.get_ascii_text(screenshot)
         #logger.info(f"ascii_text=\n{ascii_text}")
 

--- a/openadapt/strategies/mixins/ascii.py
+++ b/openadapt/strategies/mixins/ascii.py
@@ -4,6 +4,7 @@ Implements a ReplayStrategy mixin for converting images to ASCII.
 Usage:
 
     class MyReplayStrategy(ASCIIReplayStrategyMixin):
+        """ """
         ...
 """
 
@@ -20,6 +21,7 @@ MONOCHROME = True
 
 
 class ASCIIReplayStrategyMixin(BaseReplayStrategy):
+    """ """
 
     def __init__(
         self,
@@ -35,6 +37,14 @@ class ASCIIReplayStrategyMixin(BaseReplayStrategy):
         width_ratio: float = WIDTH_RATIO,
 
     ):
+        """
+
+        :param screenshot: Screenshot: 
+        :param monochrome: bool:  (Default value = MONOCHROME)
+        :param columns: int:  (Default value = COLUMNS)
+        :param width_ratio: float:  (Default value = WIDTH_RATIO)
+
+        """
         ascii_art = AsciiArt.from_pillow_image(screenshot.image)
         ascii_text = ascii_art.to_ascii(
             monochrome=monochrome,

--- a/openadapt/strategies/mixins/ascii.py
+++ b/openadapt/strategies/mixins/ascii.py
@@ -39,6 +39,14 @@ class ASCIIReplayStrategyMixin(BaseReplayStrategy):
     ):
         """
 
+        :param screenshot: Screenshot:
+        :param monochrome: bool:  (Default value = MONOCHROME)
+        :param columns: int:  (Default value = COLUMNS)
+        :param width_ratio: float:  (Default value = WIDTH_RATIO)
+        :param screenshot: Screenshot:
+        :param monochrome: bool:  (Default value = MONOCHROME)
+        :param columns: int:  (Default value = COLUMNS)
+        :param width_ratio: float:  (Default value = WIDTH_RATIO)
         :param screenshot: Screenshot: 
         :param monochrome: bool:  (Default value = MONOCHROME)
         :param columns: int:  (Default value = COLUMNS)

--- a/openadapt/strategies/mixins/huggingface.py
+++ b/openadapt/strategies/mixins/huggingface.py
@@ -4,6 +4,7 @@ Implements a ReplayStrategy mixin for generating completions with HuggingFace.
 Usage:
 
     class MyReplayStrategy(LLMReplayStrategyMixin):
+        """ """
         ...
 """
 
@@ -20,6 +21,7 @@ MAX_INPUT_SIZE = 1024
 
 
 class HuggingFaceReplayStrategyMixin(BaseReplayStrategy):
+    """ """
 
     def __init__(
         self,
@@ -39,6 +41,12 @@ class HuggingFaceReplayStrategyMixin(BaseReplayStrategy):
         prompt: str,
         max_tokens: int,
     ):
+        """
+
+        :param prompt: str: 
+        :param max_tokens: int: 
+
+        """
         max_input_size = self.max_input_size
         if max_input_size and len(prompt) > max_input_size:
             logger.warning(

--- a/openadapt/strategies/mixins/huggingface.py
+++ b/openadapt/strategies/mixins/huggingface.py
@@ -43,6 +43,10 @@ class HuggingFaceReplayStrategyMixin(BaseReplayStrategy):
     ):
         """
 
+        :param prompt: str:
+        :param max_tokens: int:
+        :param prompt: str:
+        :param max_tokens: int:
         :param prompt: str: 
         :param max_tokens: int: 
 

--- a/openadapt/strategies/mixins/ocr.py
+++ b/openadapt/strategies/mixins/ocr.py
@@ -44,6 +44,8 @@ class OCRReplayStrategyMixin(BaseReplayStrategy):
     ):
         """
 
+        :param screenshot: Screenshot:
+        :param screenshot: Screenshot:
         :param screenshot: Screenshot: 
 
         """
@@ -70,8 +72,11 @@ def get_text_df(
     			[tr_x, tr_y],
     			[br_x, br_y],
     			[bl_x, bl_y]
+    :param result: List[List[Union[List[float]:
+    :param str: param float]]]:
+    :param result: List[List[Union[List[float]:
+    :param float: returns: pd.DataFrame
     :param result: List[List[Union[List[float]: 
-    :param str: 
     :param float]]]: 
     :returns: pd.DataFrame
 
@@ -97,6 +102,8 @@ def get_text_from_df(
     """Converts a DataFrame produced by get_text_df into a string.
 
     :param df: DataFrame produced by get_text_df
+    :param df: pd.DataFrame:
+    :param df: pd.DataFrame:
     :param df: pd.DataFrame: 
     :returns: str
 
@@ -115,9 +122,9 @@ def get_text_from_df(
 def unnest(df, explode, axis, suffixes=None):
     """
 
-    :param df: 
-    :param explode: 
-    :param axis: 
+    :param df: param explode:
+    :param axis: param suffixes:  (Default value = None)
+    :param explode: param suffixes:  (Default value = None)
     :param suffixes:  (Default value = None)
 
     """
@@ -188,7 +195,7 @@ def sort_rows(df):
 def cluster_lines(df, eps):
     """
 
-    :param df: 
+    :param df: param eps:
     :param eps: 
 
     """

--- a/openadapt/strategies/mixins/openai.py
+++ b/openadapt/strategies/mixins/openai.py
@@ -57,6 +57,10 @@ class OpenAIReplayStrategyMixin(BaseReplayStrategy):
     ):
         """
 
+        :param prompt: str:
+        :param system_message: str:
+        :param prompt: str:
+        :param system_message: str:
         :param prompt: str: 
         :param system_message: str: 
         :param #max_tokens: int: 
@@ -99,8 +103,8 @@ def create_openai_completion(
 ):
     """
 
-    :param model: 
-    :param messages: 
+    :param model: param messages:
+    :param messages: param # temperatere:  (Default value = 1)
     :param # temperatere:  (Default value = 1)
     :param # top_p:  (Default value = 1)
     :param # n:  (Default value = 1)
@@ -137,9 +141,9 @@ def get_completion(
 ):
     """
 
-    :param messages: 
+    :param messages: param prompt:
+    :param model: Default value = "gpt-4")
     :param prompt: 
-    :param model:  (Default value = "gpt-4")
 
     """
 
@@ -160,6 +164,8 @@ def get_completion(
     ) -> str:
         """TODO
 
+        :param prompt: str:
+        :param prompt: str:
         :param prompt: str: 
 
         """
@@ -203,8 +209,8 @@ def get_completion(
 def num_tokens_from_messages(messages, model="gpt-3.5-turbo-0301"):
     """Returns the number of tokens used by a list of messages.
 
-    :param messages: 
-    :param model:  (Default value = "gpt-3.5-turbo-0301")
+    :param messages: param model:  (Default value = "gpt-3.5-turbo-0301")
+    :param model: Default value = "gpt-3.5-turbo-0301")
 
     """
     try:

--- a/openadapt/strategies/mixins/openai.py
+++ b/openadapt/strategies/mixins/openai.py
@@ -4,6 +4,7 @@ Implements a ReplayStrategy mixin for generating LLM completions.
 Usage:
 
     class MyReplayStrategy(OpenAIReplayStrategyMixin):
+        """ """
         ...
 """
 
@@ -34,6 +35,7 @@ encoding = tiktoken.get_encoding("cl100k_base")
 
 
 class OpenAIReplayStrategyMixin(BaseReplayStrategy):
+    """ """
 
     def __init__(
         self,
@@ -53,6 +55,13 @@ class OpenAIReplayStrategyMixin(BaseReplayStrategy):
         system_message: str,
         #max_tokens: int,
     ):
+        """
+
+        :param prompt: str: 
+        :param system_message: str: 
+        :param #max_tokens: int: 
+
+        """
         messages = [
             {
                 "role": "system",
@@ -88,6 +97,22 @@ def create_openai_completion(
     # logit_bias=None,
     # user=None,
 ):
+    """
+
+    :param model: 
+    :param messages: 
+    :param # temperatere:  (Default value = 1)
+    :param # top_p:  (Default value = 1)
+    :param # n:  (Default value = 1)
+    :param # stream:  (Default value = False)
+    :param # stop:  (Default value = None)
+    :param # max_tokens:  (Default value = inf)
+    :param # presence_penalty:  (Default value = 0)
+    :param # frequency_penalty:  (Default value = 0)
+    :param # logit_bias:  (Default value = None)
+    :param # user:  (Default value = None)
+
+    """
     return openai.ChatCompletion.create(
         model=model,
         messages=messages,
@@ -110,6 +135,13 @@ def get_completion(
     prompt,
     model="gpt-4",
 ):
+    """
+
+    :param messages: 
+    :param prompt: 
+    :param model:  (Default value = "gpt-4")
+
+    """
 
     logger.info(f"{prompt=}")
 
@@ -126,7 +158,11 @@ def get_completion(
     def _get_completion(
         prompt: str,
     ) -> str:
-        """TODO"""
+        """TODO
+
+        :param prompt: str: 
+
+        """
 
         try:
             completion = create_openai_completion(model, messages)
@@ -165,7 +201,12 @@ def get_completion(
 # XXX TODO not currently in use
 # https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
 def num_tokens_from_messages(messages, model="gpt-3.5-turbo-0301"):
-    """Returns the number of tokens used by a list of messages."""
+    """Returns the number of tokens used by a list of messages.
+
+    :param messages: 
+    :param model:  (Default value = "gpt-3.5-turbo-0301")
+
+    """
     try:
         encoding = tiktoken.encoding_for_model(model)
     except KeyError:

--- a/openadapt/strategies/naive.py
+++ b/openadapt/strategies/naive.py
@@ -46,6 +46,8 @@ class NaiveReplayStrategy(strategies.base.BaseReplayStrategy):
     ):
         """
 
+        :param screenshot: models.Screenshot:
+        :param window_event: models.WindowEvent:
         :param screenshot: models.Screenshot: 
         :param window_event: models.WindowEvent: 
 

--- a/openadapt/strategies/naive.py
+++ b/openadapt/strategies/naive.py
@@ -19,6 +19,7 @@ SLEEP = False
 
 
 class NaiveReplayStrategy(strategies.base.BaseReplayStrategy):
+    """ """
 
     def __init__(
         self,
@@ -43,6 +44,12 @@ class NaiveReplayStrategy(strategies.base.BaseReplayStrategy):
         screenshot: models.Screenshot,
         window_event: models.WindowEvent,
     ):
+        """
+
+        :param screenshot: models.Screenshot: 
+        :param window_event: models.WindowEvent: 
+
+        """
         if self.process_events:
             action_events = self.recording.processed_action_events
         else:

--- a/openadapt/strategies/stateful.py
+++ b/openadapt/strategies/stateful.py
@@ -25,6 +25,7 @@ class StatefulReplayStrategy(
     OpenAIReplayStrategyMixin,
     strategies.base.BaseReplayStrategy,
 ):
+    """ """
 
     def __init__(
         self,
@@ -49,6 +50,12 @@ class StatefulReplayStrategy(
         active_screenshot: models.Screenshot,
         active_window: models.WindowEvent,
     ):
+        """
+
+        :param active_screenshot: models.Screenshot: 
+        :param active_window: models.WindowEvent: 
+
+        """
         logger.debug(f"{self.recording_action_idx=}")
         if self.recording_action_idx == len(self.recording.processed_action_events):
             raise StopIteration()
@@ -128,6 +135,11 @@ class StatefulReplayStrategy(
 
 
 def get_action_dict_from_completion(completion):
+    """
+
+    :param completion: 
+
+    """
     try:
         action = eval(completion)
     except Exception as exc:
@@ -140,6 +152,12 @@ def get_window_state_diffs(
     action_events,
     ignore_boundary_windows=IGNORE_BOUNDARY_WINDOWS,
 ):
+    """
+
+    :param action_events: 
+    :param ignore_boundary_windows:  (Default value = IGNORE_BOUNDARY_WINDOWS)
+
+    """
     ignore_window_ids = set()
     if ignore_boundary_windows:
         first_window_event = action_events[0].window_event

--- a/openadapt/strategies/stateful.py
+++ b/openadapt/strategies/stateful.py
@@ -52,6 +52,8 @@ class StatefulReplayStrategy(
     ):
         """
 
+        :param active_screenshot: models.Screenshot:
+        :param active_window: models.WindowEvent:
         :param active_screenshot: models.Screenshot: 
         :param active_window: models.WindowEvent: 
 
@@ -154,7 +156,7 @@ def get_window_state_diffs(
 ):
     """
 
-    :param action_events: 
+    :param action_events: param ignore_boundary_windows:  (Default value = IGNORE_BOUNDARY_WINDOWS)
     :param ignore_boundary_windows:  (Default value = IGNORE_BOUNDARY_WINDOWS)
 
     """

--- a/openadapt/utils.py
+++ b/openadapt/utils.py
@@ -18,6 +18,12 @@ EMPTY = (None, [], {}, "")
 
 
 def configure_logging(logger, log_level):
+    """
+
+    :param logger: 
+    :param log_level: 
+
+    """
     log_level_override = os.getenv("LOG_LEVEL")
     log_level = log_level_override or log_level
     logger.remove()
@@ -26,6 +32,12 @@ def configure_logging(logger, log_level):
 
 
 def row2dict(row, follow=True):
+    """
+
+    :param row: 
+    :param follow:  (Default value = True)
+
+    """
     if isinstance(row, dict):
         return row
     try_follow = [
@@ -50,6 +62,12 @@ def row2dict(row, follow=True):
 
 
 def round_timestamps(events, num_digits):
+    """
+
+    :param events: 
+    :param num_digits: 
+
+    """
     for event in events:
         if isinstance(event, dict):
             continue
@@ -66,6 +84,14 @@ def rows2dicts(
     drop_constant=True,
     num_digits=None,
 ):
+    """
+
+    :param rows: 
+    :param drop_empty:  (Default value = True)
+    :param drop_constant:  (Default value = True)
+    :param num_digits:  (Default value = None)
+
+    """
     if num_digits:
         round_timestamps(rows, num_digits)
     row_dicts = [row2dict(row) for row in rows]
@@ -104,10 +130,16 @@ def rows2dicts(
 
 
 def override_double_click_interval_seconds(override_value):
+    """
+
+    :param override_value: 
+
+    """
     get_double_click_interval_seconds.override_value = override_value
 
 
 def get_double_click_interval_seconds():
+    """ """
     if hasattr(get_double_click_interval_seconds, "override_value"):
         return get_double_click_interval_seconds.override_value
     if sys.platform == "darwin":
@@ -122,6 +154,7 @@ def get_double_click_interval_seconds():
 
 
 def get_double_click_distance_pixels():
+    """ """
     if sys.platform == "darwin":
         # From https://developer.apple.com/documentation/appkit/nspressgesturerecognizer/1527495-allowablemovement:
         #     The default value of this property is the same as the
@@ -143,6 +176,7 @@ def get_double_click_distance_pixels():
 
 
 def get_monitor_dims():
+    """ """
     sct = mss.mss()
     monitor = sct.monitors[0]
     monitor_width = monitor["width"]
@@ -158,6 +192,18 @@ def draw_ellipse(
     outline_transparency=.5,
     outline_width=2,
 ):
+    """
+
+    :param x: 
+    :param y: 
+    :param image: 
+    :param width_pct:  (Default value = .03)
+    :param height_pct:  (Default value = .03)
+    :param fill_transparency:  (Default value = .25)
+    :param outline_transparency:  (Default value = .5)
+    :param outline_width:  (Default value = 2)
+
+    """
     overlay = Image.new("RGBA", image.size)
     draw = ImageDraw.Draw(overlay)
     max_dim = max(image.size)
@@ -178,6 +224,12 @@ def draw_ellipse(
 
 
 def get_font(original_font_name, font_size):
+    """
+
+    :param original_font_name: 
+    :param font_size: 
+
+    """
     font_names = [
         original_font_name,
         original_font_name.lower(),
@@ -201,6 +253,25 @@ def draw_text(
     outline=False,
     outline_padding=10,
 ):
+    """
+
+    :param x: 
+    :param y: 
+    :param text: 
+    :param image: 
+    :param font_size_pct:  (Default value = 0.01)
+    :param font_name:  (Default value = "Arial.ttf")
+    :param fill:  (Default value = (255)
+    :param 0: 
+    :param 0): 
+    :param stroke_fill:  (Default value = (255)
+    :param 255: 
+    :param 255): 
+    :param stroke_width:  (Default value = 3)
+    :param outline:  (Default value = False)
+    :param outline_padding:  (Default value = 10)
+
+    """
     overlay = Image.new("RGBA", image.size)
     draw = ImageDraw.Draw(overlay)
     max_dim = max(image.size)
@@ -245,6 +316,27 @@ def draw_rectangle(
     outline_width=2,
     invert=False,
 ):
+    """
+
+    :param x0: 
+    :param y0: 
+    :param x1: 
+    :param y1: 
+    :param image: 
+    :param bg_color:  (Default value = (0)
+    :param 0: 
+    :param 0): 
+    :param fg_color:  (Default value = (255)
+    :param 255: 
+    :param 255): 
+    :param outline_color:  (Default value = (255)
+    :param bg_transparency:  (Default value = 0.25)
+    :param fg_transparency:  (Default value = 0)
+    :param outline_transparency:  (Default value = 0.5)
+    :param outline_width:  (Default value = 2)
+    :param invert:  (Default value = False)
+
+    """
     if invert:
         bg_color, fg_color = fg_color, bg_color
         bg_transparency, fg_transparency = fg_transparency, bg_transparency
@@ -262,6 +354,11 @@ def draw_rectangle(
 
 
 def get_scale_ratios(action_event):
+    """
+
+    :param action_event: 
+
+    """
     recording = action_event.recording
     image = action_event.screenshot.image
     width_ratio = image.width / recording.monitor_width
@@ -277,6 +374,16 @@ def display_event(
     marker_outline_transparency=.5,
     diff=False,
 ):
+    """
+
+    :param action_event: 
+    :param marker_width_pct:  (Default value = .03)
+    :param marker_height_pct:  (Default value = .03)
+    :param marker_fill_transparency:  (Default value = .25)
+    :param marker_outline_transparency:  (Default value = .5)
+    :param diff:  (Default value = False)
+
+    """
     recording = action_event.recording
     window_event = action_event.window_event
     screenshot = action_event.screenshot
@@ -331,6 +438,11 @@ def display_event(
 
 
 def image2utf8(image):
+    """
+
+    :param image: 
+
+    """
     image = image.convert("RGB")
     buffered = BytesIO()
     image.save(buffered, format="JPEG")
@@ -346,6 +458,11 @@ _start_perf_counter = None
 
 
 def set_start_time(value=None):
+    """
+
+    :param value:  (Default value = None)
+
+    """
     global _start_time
     _start_time = value or time.time()
     logger.debug(f"{_start_time=}")
@@ -353,12 +470,23 @@ def set_start_time(value=None):
 
 
 def get_timestamp(is_global=False):
+    """
+
+    :param is_global:  (Default value = False)
+
+    """
     global _start_time
     return _start_time + time.perf_counter()
 
 
 # https://stackoverflow.com/a/50685454
 def evenly_spaced(arr, N):
+    """
+
+    :param arr: 
+    :param N: 
+
+    """
     if N >= len(arr):
         return arr
     idxs = set(np.round(np.linspace(0, len(arr) - 1, N)).astype(int))
@@ -366,6 +494,7 @@ def evenly_spaced(arr, N):
 
 
 def take_screenshot() -> mss.base.ScreenShot:
+    """ """
     with mss.mss() as sct:
         # monitor 0 is all in one
         monitor = sct.monitors[0]
@@ -374,6 +503,7 @@ def take_screenshot() -> mss.base.ScreenShot:
 
 
 def get_strategy_class_by_name():
+    """ """
     from openadapt.strategies import BaseReplayStrategy
     strategy_classes = BaseReplayStrategy.__subclasses__()
     class_by_name = {
@@ -385,6 +515,11 @@ def get_strategy_class_by_name():
 
 
 def strip_element_state(action_event):
+    """
+
+    :param action_event: 
+
+    """
     action_event.element_state = None
     for child in action_event.children:
         strip_element_state(child)

--- a/openadapt/visualize.py
+++ b/openadapt/visualize.py
@@ -71,6 +71,12 @@ CSS = string.Template("""
 
 
 def recursive_len(lst, key):
+    """
+
+    :param lst: 
+    :param key: 
+
+    """
     try:
         _len = len(lst)
     except TypeError:
@@ -84,6 +90,12 @@ def recursive_len(lst, key):
 
 
 def format_key(key, value):
+    """
+
+    :param key: 
+    :param value: 
+
+    """
     if isinstance(value, list):
         return f"{key} ({len(value)}; {recursive_len(value, key)})"
     else:
@@ -91,6 +103,13 @@ def format_key(key, value):
 
 
 def indicate_missing(some, every, indicator):
+    """
+
+    :param some: 
+    :param every: 
+    :param indicator: 
+
+    """
     rval = []
     some_idx = 0
     every_idx = 0
@@ -108,6 +127,12 @@ def indicate_missing(some, every, indicator):
 
 
 def dict2html(obj, max_children=MAX_TABLE_CHILDREN):
+    """
+
+    :param obj: 
+    :param max_children:  (Default value = MAX_TABLE_CHILDREN)
+
+    """
     if isinstance(obj, list):
         children = [dict2html(value, max_children) for value in obj]
         if max_children is not None and len(children) > max_children:
@@ -133,6 +158,7 @@ def dict2html(obj, max_children=MAX_TABLE_CHILDREN):
 
 
 def main():
+    """ """
     configure_logging(logger, LOG_LEVEL)
 
     recording = get_latest_recording()
@@ -224,6 +250,7 @@ def main():
 
 
     def cleanup():
+        """ """
         os.remove(fname_out)
         removed = not os.path.exists(fname_out)
         logger.info(f"{removed=}")

--- a/openadapt/window/__init__.py
+++ b/openadapt/window/__init__.py
@@ -49,7 +49,7 @@ def get_active_window_state():
 def get_active_element_state(x, y):
     """
 
-    :param x: 
+    :param x: param y:
     :param y: 
 
     """

--- a/openadapt/window/__init__.py
+++ b/openadapt/window/__init__.py
@@ -13,6 +13,7 @@ else:
 
 
 def get_active_window_data():
+    """ """
     state = get_active_window_state()
     if not state:
         return None
@@ -35,6 +36,7 @@ def get_active_window_data():
 
 
 def get_active_window_state():
+    """ """
     # TODO: save window identifier (a window's title can change, or
     # multiple windows can have the same title)
     try:
@@ -45,6 +47,12 @@ def get_active_window_state():
 
 
 def get_active_element_state(x, y):
+    """
+
+    :param x: 
+    :param y: 
+
+    """
     try:
         return impl.get_active_element_state(x, y)
     except Exception as exc:

--- a/openadapt/window/_macos.py
+++ b/openadapt/window/_macos.py
@@ -92,7 +92,7 @@ def get_window_data(window_meta):
 def dump_state(element, elements=None):
     """
 
-    :param element: 
+    :param element: param elements:  (Default value = None)
     :param elements:  (Default value = None)
 
     """
@@ -172,7 +172,7 @@ def deepconvert_objc(object):
 def get_active_element_state(x, y):
     """
 
-    :param x: 
+    :param x: param y:
     :param y: 
 
     """

--- a/openadapt/window/_macos.py
+++ b/openadapt/window/_macos.py
@@ -9,6 +9,7 @@ import Quartz
 
 
 def get_active_window_state():
+    """ """
     # pywinctl performance on mac is unusable, see:
     # https://github.com/Kalmat/PyWinCtl/issues/29
     meta = get_active_window_meta()
@@ -45,6 +46,7 @@ def get_active_window_state():
 
 
 def get_active_window_meta():
+    """ """
     windows = Quartz.CGWindowListCopyWindowInfo(
         (
             Quartz.kCGWindowListExcludeDesktopElements |
@@ -60,6 +62,11 @@ def get_active_window_meta():
 
 
 def get_active_window(window_meta):
+    """
+
+    :param window_meta: 
+
+    """
     pid = window_meta["kCGWindowOwnerPID"]
     app_ref = ApplicationServices.AXUIElementCreateApplication(pid)
     error_code, window = ApplicationServices.AXUIElementCopyAttributeValue(
@@ -72,12 +79,23 @@ def get_active_window(window_meta):
 
 
 def get_window_data(window_meta):
+    """
+
+    :param window_meta: 
+
+    """
     window = get_active_window(window_meta)
     state = dump_state(window)
     return state
 
 
 def dump_state(element, elements=None):
+    """
+
+    :param element: 
+    :param elements:  (Default value = None)
+
+    """
     elements = elements or set()
     if element in elements:
         return
@@ -133,7 +151,11 @@ def dump_state(element, elements=None):
 
 # https://github.com/autopkg/autopkg/commit/1aff762d8ea658b3fca8ac693f3bf13e8baf8778
 def deepconvert_objc(object):
-    """Convert all contents of an ObjC object to Python primitives."""
+    """Convert all contents of an ObjC object to Python primitives.
+
+    :param object: 
+
+    """
     value = object
     if isinstance(object, AppKit.NSNumber):
         value = int(object)
@@ -148,6 +170,12 @@ def deepconvert_objc(object):
 
 
 def get_active_element_state(x, y):
+    """
+
+    :param x: 
+    :param y: 
+
+    """
     window_meta = get_active_window_meta()
     pid = window_meta["kCGWindowOwnerPID"]
     app = atomacos._a11y.AXUIElement.from_pid(pid)
@@ -163,6 +191,7 @@ def get_active_element_state(x, y):
 
 
 def main():
+    """ """
     import time
     time.sleep(1)
 

--- a/openadapt/window/_windows.py
+++ b/openadapt/window/_windows.py
@@ -29,7 +29,7 @@ def get_active_window_state():
 def get_element_at_position(x, y):
     """
 
-    :param x: 
+    :param x: param y:
     :param y: 
 
     """

--- a/openadapt/window/_windows.py
+++ b/openadapt/window/_windows.py
@@ -3,6 +3,7 @@ import pygetwindow as pgw
 
 
 def get_active_window_state():
+    """ """
     window = pgw.getActiveWindow()
     if not window:
         logger.warning(f"{window=}")
@@ -26,5 +27,11 @@ def get_active_window_state():
 
 
 def get_element_at_position(x, y):
+    """
+
+    :param x: 
+    :param y: 
+
+    """
     # TODO
     return None

--- a/tests/openadapt/test_events.py
+++ b/tests/openadapt/test_events.py
@@ -39,6 +39,7 @@ timestamp_raw = _start_time
 
 
 def reset_timestamp():
+    """ """
     global timestamp
     global timestamp_raw
     timestamp = _start_time
@@ -47,6 +48,7 @@ def reset_timestamp():
 
 @pytest.fixture(autouse=True)
 def _reset_timestamp():
+    """ """
     reset_timestamp()
 
 
@@ -56,6 +58,14 @@ def make_action_event(
     get_pre_children=None,
     get_post_children=None,
 ):
+    """
+
+    :param event_dict: 
+    :param dt:  (Default value = None)
+    :param get_pre_children:  (Default value = None)
+    :param get_post_children:  (Default value = None)
+
+    """
     assert "chidren" not in event_dict, event_dict["children"]
     children = get_children_with_timestamps(get_pre_children)
     event_dict["children"] = children
@@ -91,6 +101,11 @@ def make_action_event(
 
 
 def get_children_with_timestamps(get_children):
+    """
+
+    :param get_children: 
+
+    """
     if not get_children:
         return []
 
@@ -111,6 +126,14 @@ def get_children_with_timestamps(get_children):
 
 
 def make_move_event(x=0, y=0, get_pre_children=None, get_post_children=None):
+    """
+
+    :param x:  (Default value = 0)
+    :param y:  (Default value = 0)
+    :param get_pre_children:  (Default value = None)
+    :param get_post_children:  (Default value = None)
+
+    """
     return make_action_event(
         {
             "name": "move",
@@ -131,6 +154,17 @@ def make_click_event(
     get_pre_children=None,
     get_post_children=None,
 ):
+    """
+
+    :param pressed: 
+    :param mouse_x:  (Default value = 0)
+    :param mouse_y:  (Default value = 0)
+    :param dt:  (Default value = None)
+    :param button_name:  (Default value = "left")
+    :param get_pre_children:  (Default value = None)
+    :param get_post_children:  (Default value = None)
+
+    """
     return make_action_event(
         {
             "name": "click",
@@ -146,6 +180,12 @@ def make_click_event(
 
 
 def make_scroll_event(dy=0, dx=0):
+    """
+
+    :param dy:  (Default value = 0)
+    :param dx:  (Default value = 0)
+
+    """
     return make_action_event({
         "name": "scroll",
         "mouse_dx": dx,
@@ -154,6 +194,13 @@ def make_scroll_event(dy=0, dx=0):
 
 
 def make_click_events(dt_released, dt_pressed=None, button_name="left"):
+    """
+
+    :param dt_released: 
+    :param dt_pressed:  (Default value = None)
+    :param button_name:  (Default value = "left")
+
+    """
     return (
         make_click_event(True, dt=dt_pressed, button_name=button_name),
         make_click_event(False, dt=dt_released, button_name=button_name),
@@ -163,6 +210,16 @@ def make_click_events(dt_released, dt_pressed=None, button_name="left"):
 def make_processed_click_event(
     name, dt, get_children, mouse_x=0, mouse_y=0, button_name="left",
 ):
+    """
+
+    :param name: 
+    :param dt: 
+    :param get_children: 
+    :param mouse_x:  (Default value = 0)
+    :param mouse_y:  (Default value = 0)
+    :param button_name:  (Default value = "left")
+
+    """
     return make_action_event(
         {
             "name": name,
@@ -178,6 +235,15 @@ def make_processed_click_event(
 def make_singleclick_event(
     dt, get_children, mouse_x=0, mouse_y=0, button_name="left",
 ):
+    """
+
+    :param dt: 
+    :param get_children: 
+    :param mouse_x:  (Default value = 0)
+    :param mouse_y:  (Default value = 0)
+    :param button_name:  (Default value = "left")
+
+    """
     return make_processed_click_event(
         "singleclick",
         dt,
@@ -191,6 +257,15 @@ def make_singleclick_event(
 def make_doubleclick_event(
     dt, get_children, mouse_x=0, mouse_y=0, button_name="left",
 ):
+    """
+
+    :param dt: 
+    :param get_children: 
+    :param mouse_x:  (Default value = 0)
+    :param mouse_y:  (Default value = 0)
+    :param button_name:  (Default value = "left")
+
+    """
     return make_processed_click_event(
         "doubleclick",
         dt,
@@ -202,6 +277,7 @@ def make_doubleclick_event(
 
 
 def test_merge_consecutive_mouse_click_events():
+    """ """
     if OVERRIDE_DOUBLE_CLICK_INTERVAL_SECONDS:
         override_double_click_interval_seconds(
             OVERRIDE_DOUBLE_CLICK_INTERVAL_SECONDS
@@ -260,6 +336,7 @@ def test_merge_consecutive_mouse_click_events():
 
 
 def test_merge_consecutive_mouse_move_events():
+    """ """
     raw_events = [
         make_scroll_event(),
         make_move_event(0),
@@ -297,6 +374,7 @@ def test_merge_consecutive_mouse_move_events():
 
 
 def test_merge_consecutive_mouse_scroll_events():
+    """ """
     raw_events = [
         make_move_event(),
         make_scroll_event(dx=2),
@@ -323,6 +401,7 @@ def test_merge_consecutive_mouse_scroll_events():
 
 
 def test_remove_redundant_mouse_move_events():
+    """ """
     # certain failure modes only appear in longer event chains
     raw_events = list(itertools.chain(*[
         [
@@ -376,6 +455,12 @@ def test_remove_redundant_mouse_move_events():
 
 
 def make_press_event(char=None, name=None):
+    """
+
+    :param char:  (Default value = None)
+    :param name:  (Default value = None)
+
+    """
     assert (char or name) and not (char and name), (char, name)
     return make_action_event({
         "name": "press",
@@ -385,6 +470,12 @@ def make_press_event(char=None, name=None):
 
 
 def make_release_event(char=None, name=None):
+    """
+
+    :param char:  (Default value = None)
+    :param name:  (Default value = None)
+
+    """
     assert (char or name) and not (char and name), (char, name)
     return make_action_event({
         "name": "release",
@@ -394,6 +485,11 @@ def make_release_event(char=None, name=None):
 
 
 def make_type_event(get_children):
+    """
+
+    :param get_children: 
+
+    """
     return make_action_event(
         {
             "name": "type",
@@ -403,10 +499,16 @@ def make_type_event(get_children):
 
 
 def make_key_events(char):
+    """
+
+    :param char: 
+
+    """
     return make_press_event(char), make_release_event(char)
 
 
 def test_merge_consecutive_keyboard_events():
+    """ """
     raw_events = [
         make_click_event(True),
         *make_key_events("a"),
@@ -455,6 +557,7 @@ def test_merge_consecutive_keyboard_events():
 
 
 def test_merge_consecutive_keyboard_events__grouped():
+    """ """
     raw_events = [
         make_click_event(True),
         *make_key_events("a"),
@@ -503,10 +606,16 @@ def test_merge_consecutive_keyboard_events__grouped():
 
 
 def make_window_event(event_dict):
+    """
+
+    :param event_dict: 
+
+    """
     return WindowEvent(**event_dict)
 
 
 def test_discard_unused_events():
+    """ """
     window_events = [
         make_window_event({"timestamp": 0}),
         make_window_event({"timestamp": 1}),


### PR DESCRIPTION
#181 
Ran `pyment -w openadapt` (including nested directories)

Please see the diff, it has added quite a bit, along with some empty docstrings for functions that have no params or return vals.

Are there any particular styles we want?

The current options are:
["javadoc", "reST", "numpydoc", "google"] (default "reST")