### PR TITLE
Use pickle.HIGHEST_PROTOCOL

### DIFF
--- a/openadapt/window/_macos.py
+++ b/openadapt/window/_macos.py
@@ -37,7 +37,7 @@ def get_active_window_state():
     }
     rval = deepconvert_objc(rval)
     try:
-        pickle.dumps(rval)
+        pickle.dumps(rval, protocol=pickle.HIGHEST_PROTOCOL)
     except Exception as exc:
         logger.warning(f"{exc=}")
         rval.pop("data")
@@ -155,7 +155,7 @@ def get_active_element_state(x, y):
     state = dump_state(el.ref)
     state = deepconvert_objc(state)
     try:
-        pickle.dumps(state)
+        pickle.dumps(state, protocol=pickle.HIGHEST_PROTOCOL)
     except Exception as exc:
         logger.warning(f"{exc=}")
         state = {}
@@ -168,7 +168,7 @@ def main():
 
     state = get_active_window_state()
     pprint(state)
-    pickle.dumps(state)
+    pickle.dumps(state, protocol=pickle.HIGHEST_PROTOCOL)
     import ipdb; ipdb.set_trace()
 
 


### PR DESCRIPTION
- Closes #177 

Looks like newer python versions already use `cpickle` (now called `_pickle`). 
I checked my local `pickle.py`:
```python
# Use the faster _pickle if possible
try:
    from _pickle import (
        PickleError,
        PicklingError,
        UnpicklingError,
        Pickler,
        Unpickler,
        dump,
        dumps,
        load,
        loads
    )
except ImportError:
    Pickler, Unpickler = _Pickler, _Unpickler
    dump, dumps, load, loads = _dump, _dumps, _load, _loads
 ``` 
 > **Note** The pickle module has an transparent optimizer (_pickle) written in C. It is used whenever available. Otherwise the pure Python implementation is used.
 
 I decided to run some serialization tests to verify if this was true, comparing `pickle`, `_pickle`, `dill`, and a new one I found - [cloudpickle](https://github.com/cloudpipe/cloudpickle). I also noticed that there's a `protocol` parameter we can pass, currently we use protocol 4 (the default) 
 Here's the tests ([gist](https://gist.github.com/0dm/9170f98e5cf17a28cb74eb195e834744/)):
 ```python
 import numpy as np
import pickle
import dill
import _pickle
import cloudpickle
import timeit

arr = np.random.default_rng(1991).random((100, 100, 100))

timings = {}

for package in ["dill", "pickle", "_pickle", "cloudpickle"]:
    timings[package] = {}
    for protocol in [4, 5]:
        cmd = f"{package}.dumps(arr, protocol={protocol})"
        val = timeit.timeit(cmd, globals=locals(), number=1000)
        timings[package][protocol] = val
        print(f"{cmd} = {val}")
    print()
 ```
 `python -m openadapt.test_pickles`
 
![Figure_1](https://github.com/MLDSAI/OpenAdapt/assets/57018940/2f4660c6-6ddd-42ed-8852-4a55be19919d)


 ```python
dill.dumps(arr, protocol=4) = 1.745939874999749
dill.dumps(arr, protocol=5) = 1.7287742500011518

pickle.dumps(arr, protocol=4) = 0.8611212499999965
pickle.dumps(arr, protocol=5) = 0.2734048750025977

_pickle.dumps(arr, protocol=4) = 0.8723926249986107
_pickle.dumps(arr, protocol=5) = 0.2733791659993585

cloudpickle.dumps(arr, protocol=4) = 1.6537441660002514
cloudpickle.dumps(arr, protocol=5) = 1.0376680000008491
```
Indeed, the difference between `pickle` and `_pickle` is virtually nonexistent, suggesting that they are the same. `dill` is painfully slow in comparison, and `cloudpickle` does not seem worth using. What's interesting is how much better protocol 5 is here. 
> **Note** Protocol version 5 was added in Python 3.8. It adds support for out-of-band data and speedup for in-band data. Refer to [PEP 574](https://www.python.org/dev/peps/pep-0574) for information about improvements brought by protocol 5.

So, what should we do? It turns out we can pass `pickle.HIGHEST_PROTOCOL`, which will always select the highest possible protocol to use (currently 5). There appears to be no downside to this in our case.

This PR adds `protocol=pickle.HIGHEST_PROTOCOL` wherever necessary. I have tested a recording where I click different windows and can confirm that recording is faster now.