### PR TITLE
rename config => alembic_config (env.py)

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -7,12 +7,12 @@ from alembic import context
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
-config = context.config
+alembic_config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+if alembic_config.config_file_name is not None:
+    fileConfig(alembic_config.config_file_name)
 
 # add your model's MetaData object here
 # for 'autogenerate' support
@@ -21,6 +21,7 @@ if config.config_file_name is not None:
 from openadapt.config import DB_URL
 from openadapt.models import *
 from openadapt.db import Base
+
 target_metadata = Base.metadata
 
 # other values from the config, defined by the needs of env.py,
@@ -46,7 +47,7 @@ def run_migrations_offline() -> None:
     script output.
 
     """
-    #url = config.get_main_option("sqlalchemy.url")
+    # url = config.get_main_option("sqlalchemy.url")
     url = get_url()
     context.configure(
         url=url,
@@ -67,7 +68,7 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
-    configuration = config.get_section(config.config_ini_section)
+    configuration = alembic_config.get_section(alembic_config.config_ini_section)
     configuration["sqlalchemy.url"] = get_url()
     connectable = engine_from_config(
         configuration=configuration,


### PR DESCRIPTION
resolves the below error when running `alembic upgrade head`

```
    run_migrations_online()
  File "/Users/aaron/Documents/GitHub/OpenAdapt/alembic/env.py", line 70, in run_migrations_online
    configuration = config.get_section(config.config_ini_section)
AttributeError: module 'openadapt.config' has no attribute 'get_section'
```

fix: rename config to alembic_config in env.py