### PR TITLE
config.obfuscate

### DIFF
--- a/openadapt/config.py
+++ b/openadapt/config.py
@@ -104,9 +104,24 @@ DB_FPATH = ROOT_DIRPATH / DB_FNAME  # type: ignore # noqa
 DB_URL = f"sqlite:///{DB_FPATH}"
 DIRNAME_PERFORMANCE_PLOTS = "performance"
 
+
+def obfuscate(val, pct_reveal=0.1, char="*"):
+    num_reveal = int(len(val) * pct_reveal)
+    num_obfuscate = len(val) - num_reveal
+    obfuscated = char * num_obfuscate
+    revealed = val[-num_reveal:]
+    rval = f"{obfuscated}{revealed}"
+    assert len(rval) == len(val), (val, rval)
+    return rval
+
+
+
 if multiprocessing.current_process().name == "MainProcess":
-    for key, val in locals().items():
+    for key, val in dict(locals()).items():
         if not key.startswith("_") and key.isupper():
+            parts = key.split("_")
+            if any([phrase in parts for phrase in ("KEY", "PASSWORD", "TOKEN")]):
+                val = obfuscate(val)
             logger.info(f"{key}={val}")
 
 

--- a/openadapt/config.py
+++ b/openadapt/config.py
@@ -116,11 +116,15 @@ def obfuscate(val, pct_reveal=0.1, char="*"):
 
 
 
+_OBFUSCATE_KEY_PARTS = ("KEY", "PASSWORD", "TOKEN")
 if multiprocessing.current_process().name == "MainProcess":
     for key, val in dict(locals()).items():
         if not key.startswith("_") and key.isupper():
             parts = key.split("_")
-            if any([phrase in parts for phrase in ("KEY", "PASSWORD", "TOKEN")]):
+            if (
+                any([part in parts for part in _OBFUSCATE_KEY_PARTS]) and
+                val != _DEFAULTS[key]
+            ):
                 val = obfuscate(val)
             logger.info(f"{key}={val}")
 

--- a/openadapt/scripts/scrub.py
+++ b/openadapt/scripts/scrub.py
@@ -22,10 +22,11 @@ Example: To redact all entities in sample2.mp4
 from typing import Optional
 import math
 
-from tqdm import tqdm
+from loguru import logger
 from PIL import Image
 from moviepy.editor import VideoFileClip, VideoClip
 from moviepy.video.fx import speedx
+from tqdm import tqdm
 import fire
 import numpy as np
 
@@ -85,6 +86,12 @@ def scrub_mp4(
     Returns:
         Path to the scrubbed (redacted) mp4 file.
     """
+
+    logger.info(f"{mp4_file=}")
+    logger.info(f"{scrub_all_entities=}")
+    logger.info(f"{playback_speed_multiplier=}")
+    logger.info(f"{crop_start_time=}")
+    logger.info(f"{crop_end_time=}")
 
     if scrub_all_entities:
         config.SCRUB_IGNORE_ENTITIES = []


### PR DESCRIPTION
Resolves https://github.com/MLDSAI/OpenAdapt/issues/309

Example output:

```
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - CACHE_DIR_PATH=.cache
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - CACHE_ENABLED=True
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - CACHE_VERBOSITY=0
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - DB_ECHO=False
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - DB_FNAME=openadapt.db
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - OPENAI_API_KEY=************************v>
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - OPENAI_MODEL_NAME=gpt-3.5-turbo
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - RECORD_READ_ACTIVE_ELEMENT_STATE=False
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - REPLAY_STRIP_ELEMENT_STATE=True                         
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - IGNORE_WARNINGS=False                                   
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - ACTION_TEXT_SEP=-
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - ACTION_TEXT_NAME_PREFIX=<
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - ACTION_TEXT_NAME_SUFFIX=>
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - SCRUB_ENABLED=True                                      
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - SCRUB_CHAR=*                                            
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - SCRUB_LANGUAGE=en
2023-06-25 10:21:04.187 | INFO     | openadapt.config:<module>:125 - SCRUB_FILL_COLOR=255
2023-06-25 10:21:04.188 | INFO     | openadapt.config:<module>:125 - SCRUB_CONFIG_TRF={'nlp_engine_name': 'spacy', 'models': [{'lang_code': 'en', 'model_name': 'en_core_web_trf'}]}
2023-06-25 10:21:04.188 | INFO     | openadapt.config:<module>:125 - SCRUB_IGNORE_ENTITIES=['DATE_TIME', 'URL']              
2023-06-25 10:21:04.188 | INFO     | openadapt.config:<module>:125 - SCRUB_KEYS_HTML=['text', 'canonical_text', 'title', 'state', 'task_description', 'key_char', 'canonical_key_char', 'key_vk', 'children']
2023-06-25 10:21:04.188 | INFO     | openadapt.config:<module>:125 - ROOT_DIRPATH=/Users/abrichr/oa/OpenAdapt
2023-06-25 10:21:04.188 | INFO     | openadapt.config:<module>:125 - DB_FPATH=/Users/abrichr/oa/OpenAdapt/openadapt.db       
2023-06-25 10:21:04.188 | INFO     | openadapt.config:<module>:125 - DB_URL=sqlite:////Users/abrichr/oa/OpenAdapt/openadapt.db
2023-06-25 10:21:04.188 | INFO     | openadapt.config:<module>:125 - DIRNAME_PERFORMANCE_PLOTS=performance
```